### PR TITLE
Windows fix and downgrade fix

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -9,6 +9,8 @@ import migrations_config as config
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
+SEPARATOR = '@'
+
 DEFAULT_MIGRATION_FILE = """
 
 def upgrade(connection):
@@ -32,9 +34,10 @@ def migrate():
 @click.argument('name')
 def create(schema, name):
     timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d%H%M%S')
-    filename = f'{timestamp}:{schema}:{name}.py'
+    filename = f'{timestamp}{SEPARATOR}{schema}{SEPARATOR}{name}.py'
     click.echo(f'Creating new migration file {filename}')
-    with open(f'{CURRENT_DIRECTORY}/versions/{filename}', 'w+') as f:
+    os_path = os.path.join(CURRENT_DIRECTORY, 'versions', filename)
+    with open(os_path, 'w') as f:
         f.write(DEFAULT_MIGRATION_FILE)
 
 
@@ -60,10 +63,12 @@ def downgrade(schema, run_all, timestamp):
         click.echo('schema not found')
         return
     if run_all:
-        run_migrations(schema, migration_files_for_schema(schema), upgrade=False)
+        files = migration_files_for_schema(schema)
+        run_migrations(schema, list(reversed(files)), upgrade=False)
     if timestamp:
         click.echo(f'running downgrade on all migrations for {schema} older than {timestamp}')
-        run_migrations(schema, get_migration_files_for_schema_older_than(schema, timestamp), upgrade=False)
+        files = get_migration_files_for_schema_older_than(schema, timestamp)
+        run_migrations(schema, list(reversed(files)), upgrade=False)
     if not run_all or timestamp:
         click.echo('please use the --all or --to flag to specify the type of downgrade')
 
@@ -98,7 +103,7 @@ def run_migrations(schema, migrations_to_run, upgrade=True):
 
 
 def get_migration_filename_parts(migration_filename):
-    filename_parts = str.split(migration_filename, ':')
+    filename_parts = str.split(migration_filename, SEPARATOR)
     return filename_parts[0], filename_parts[1], filename_parts[2][:-3]
 
 
@@ -136,7 +141,7 @@ def migration_files_for_schema(schema):
         return [
             filename
             for filename in files
-            if f':{schema}:' in filename
+            if f'{SEPARATOR}{schema}{SEPARATOR}' in filename
         ]
 
 


### PR DESCRIPTION
On windows, ":" is a reserved path character, so you can't use
it as a separator.

Also, when downgrading, the files need to be run in reverse order
otherwise dependencies wont be undone first