### PR TITLE
Make the path to the versions folder configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ virtualenv/bin/activate && pip install -r requirements.txt
 Then set the `DB_URI` value in `migrations_config.py`.
 Other configurable values in the `migrations_config.py` include:
 - `SEPARATOR`: change the character used to separate the parts of migration file names, defaults to '-'
+- `VERSIONS_PATH`: the path to the directory containing your migration files, defaults to the versions directory in this repository
 
 
 ## Usage

--- a/migrations_config.py
+++ b/migrations_config.py
@@ -1,4 +1,5 @@
 import os
 
 DB_URI = os.getenv('DB_URI', 'postgres://postgres:password@localhost:5432')
+VERSIONS_PATH = os.getenv('VERSIONS_PATH', os.path.join(os.path.dirname(os.path.realpath(__file__)), 'versions'))
 SEPARATOR = '-'


### PR DESCRIPTION
Enables the use case where migration files are kept
seperate to the Simpyl code that runs them. Defaults
to the versions folder in this repo.